### PR TITLE
Add lifeline websocket support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
     "./backendTypes": "./backendTypes.ts"
   },
   "tasks": {
-    "test": "deno test --allow-env=GLUE_DEV_PORT --allow-net=127.0.0.1"
+    "test": "deno test --allow-env=GLUE_DEV_PORT,GLUE_CLI_WS_ADDR --allow-net=127.0.0.1"
   },
   "imports": {
     "@octokit/webhooks-types": "npm:@octokit/webhooks-types@^7.6.1",


### PR DESCRIPTION
Adds support for the glue process in dev mode to keep a "lifeline" connection to the glue-cli runner process, so that if the runner process dies (expectedly or unexpectedly) then the glue process will shut itself down instead of hanging around hogging resources and a listening port.

The lifeline connection being opened by the glue process can also be used to let the glue-cli runner know when the glue process is ready or when it's been restarted by the Deno `--watch` flag being used.

The glue-cli support for this will come next. This PR does not depend on glue-cli support.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-18 19:22:31 UTC

This PR adds a "lifeline" websocket connection mechanism to the Glue Runtime that enables better resource management during development. The changes introduce a websocket connection between the glue process and the glue-cli runner process, allowing the glue process to automatically shut down when the CLI runner dies or exits.

The implementation works by establishing a websocket connection to the CLI runner after the HTTP server is ready, but only in development mode (when `GLUE_DEV_PORT` is set) and when the `GLUE_CLI_WS_ADDR` environment variable is provided. When the websocket connection closes or encounters an error, the glue process exits with code 5, preventing zombie processes that would otherwise continue consuming resources like listening ports.

The change fits into the existing codebase architecture by leveraging the runtime support module's initialization flow. It hooks into the point where the HTTP server becomes ready and adds the lifeline connection as an optional development feature. The websocket connection serves dual purposes: it allows the CLI runner to detect when the glue process is ready or restarted (useful with Deno's `--watch` flag), and it ensures the glue process doesn't outlive its parent CLI runner.

This enhancement specifically targets development workflow improvements without affecting production deployments, as the lifeline is only activated when specific development environment variables are present.

## Confidence score: 4/5

- This PR is safe to merge with low risk as it only affects development mode and gracefully handles the optional nature of the lifeline connection
- Score reflects simple, well-contained changes that follow good practices for optional feature implementation and proper error handling
- Pay close attention to the `startLifeline` function implementation for proper websocket lifecycle management

<!-- /greptile_comment -->