### PR TITLE
+glue.debug

### DIFF
--- a/integrations/debug/runtime.ts
+++ b/integrations/debug/runtime.ts
@@ -1,0 +1,49 @@
+/**
+ * Debug integration exposing low-level registration helpers.
+ *
+ * These APIs are intentionally unstable and primarily meant for internal
+ * experimentation and tests. They allow registering arbitrary trigger types
+ * and account injections without the usual type-safe wrappers provided by
+ * first-class integrations.
+ */
+import {
+  type AccessTokenCredential,
+  type AccountFetcher,
+  type ApiKeyCredential,
+  registerAccountInjection,
+  registerEventListener,
+} from "../../runtimeSupport.ts";
+import type { AccountInjectionBackendConfig } from "../../backendTypes.ts";
+import type { CommonTriggerOptions } from "../../common.ts";
+
+export class Debug {
+  /**
+   * Register a raw trigger with an arbitrary type string and config object.
+   *
+   * NOTE: This must be called at module top-level before the event loop turns
+   * (consistent with all other registrations) otherwise an error will be thrown
+   * by the runtime.
+   */
+  registerRawTrigger(
+    type: string,
+    fn: (event: unknown) => void,
+    // Allow any shape; extra keys are preserved because runtime doesn't validate.
+    config?: Record<string, unknown>,
+  ): void {
+    registerEventListener(type, fn, config as unknown as CommonTriggerOptions | undefined);
+  }
+
+  /**
+   * Register a raw account injection for an arbitrary integration type.
+   *
+   * NOTE: This must be called at module top-level before the event loop turns
+   * (consistent with all other registrations) otherwise an error will be thrown
+   * by the runtime.
+   */
+  registerRawAccountInjection<T extends AccessTokenCredential | ApiKeyCredential>(
+    type: string,
+    config: AccountInjectionBackendConfig,
+  ): AccountFetcher<T> {
+    return registerAccountInjection<T>(type, config);
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -56,6 +56,7 @@ import * as streakEventSource from "./integrations/streak/runtime.ts";
 import * as stripeEventSource from "./integrations/stripe/runtime.ts";
 import * as cronEventSource from "./integrations/cron/runtime.ts";
 import * as intercomEventSource from "./integrations/intercom/runtime.ts";
+import { Debug } from "./integrations/debug/runtime.ts";
 export type { GoogleAccountInjectionOptions } from "./integrations/google/runtime.ts";
 export type { GmailMessageEvent, GmailTriggerOptions } from "./integrations/gmail/runtime.ts";
 export type { GithubEvent, GithubTriggerOptions } from "./integrations/github/runtime.ts";
@@ -121,6 +122,12 @@ class Glue {
    * Tracks events in Intercom workspaces like conversation closures.
    */
   readonly intercom: intercomEventSource.Intercom = new intercomEventSource.Intercom();
+
+  /**
+   * Debug utilities exposing low-level registration helpers.
+   * These APIs are unstable and intended for internal / experimental use.
+   */
+  readonly debug: Debug = new Debug();
 }
 
 export type { Glue };


### PR DESCRIPTION
This adds `glue.debug.registerRawTrigger` and `glue.debug.registerRawAccountInjection`, which allow making registrations that we don't have proper APIs for yet. These are mainly intended for use during development so that it's possible to work on new integrations in the backend and test them out in Glue before making changes to the runtime.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-19 21:40:08 UTC

This PR introduces a new debug integration to the Glue runtime framework, adding `glue.debug.registerRawTrigger` and `glue.debug.registerRawAccountInjection` methods. These methods provide low-level access to the runtime's registration system, allowing developers to register arbitrary trigger types and account injections without the usual type-safe wrappers.

The implementation follows the established integration pattern by creating a new Debug class in `integrations/debug/runtime.ts` and exposing it as a readonly property on the main Glue class. The debug methods intentionally bypass type checking using type assertions to provide maximum flexibility for internal experimentation. This allows backend developers to test new integration types in Glue before implementing proper runtime APIs.

The changes also update the test suite to validate the debug functionality and modify the endpoint structure from `getRegisteredTriggers` to `getRegistrations` to accommodate both triggers and account injections in a unified response. The test demonstrates registration of both a debug trigger with custom configuration and a debug account injection with custom scopes.

This addition fits well within the existing codebase architecture, maintaining the modular integration approach while providing a development escape hatch for testing experimental features.

## Confidence score: 4/5

- This PR is safe to merge with low risk as it adds isolated debug functionality without affecting existing integrations
- Score reflects well-structured implementation following established patterns, though debug methods intentionally bypass type safety
- Pay close attention to `integrations/debug/runtime.ts` for the type assertion usage and ensure debug APIs remain internal-only

### Context used:
**Context -** Always provide clear comments in the code to explain complex logic or decisions, as it aids in understanding for future developers. ([link](https://app.greptile.com/review/custom-context?memory=4f1dd8ba-73a1-4010-8f85-1f09ecaae6ba))

<!-- /greptile_comment -->