### PR TITLE
slack event source and 2 account providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ glue.streak.onBoxStageChanged("pipeline-key", (event) => {
 });
 ```
 
+### Slack
+
+Monitor messages and channel activity
+
+```typescript
+glue.slack.onUserVisibleMessage(); //TODO
+```
+
 ## Common Options
 
 All event sources support common trigger options:
@@ -224,6 +232,7 @@ All event types are fully typed with TypeScript, providing excellent IDE support
 - `CronEvent` - Scheduled task triggers
 - `StripeEvent<T>` - Stripe webhook events
 - `IntercomEvent` - Intercom webhook events
+- `SlackEventWebhook` - Slack webhook events
 - `WebflowEvent<T>` - Webflow webhook events
 - `StreakEvent` - Streak CRM events
 

--- a/backendTypes.ts
+++ b/backendTypes.ts
@@ -101,6 +101,7 @@ export { CronTriggerBackendConfig } from "./integrations/cron/runtime.ts";
 export { GithubTriggerBackendConfig } from "./integrations/github/runtime.ts";
 export { GmailTriggerBackendConfig } from "./integrations/gmail/runtime.ts";
 export { IntercomTriggerBackendConfig } from "./integrations/intercom/runtime.ts";
+export { SlackEventWebhook, SlackTriggerBackendConfig } from "./integrations/slack/runtime.ts";
 export { StreakTriggerBackendConfig } from "./integrations/streak/runtime.ts";
 export { StripeTriggerBackendConfig } from "./integrations/stripe/runtime.ts";
 export { WebhookTriggerBackendConfig } from "./integrations/webhook/runtime.ts";

--- a/common.ts
+++ b/common.ts
@@ -45,3 +45,9 @@ export const CommonAccountInjectionOptions: z.ZodObject<
 > = z.object({
   description: z.string().optional(),
 });
+
+// these are the same for now but may not be in the future
+
+/** Common backend config for all trigger configurations */
+export type CommonTriggerBackendConfig = CommonTriggerOptions;
+export const CommonTriggerBackendConfig: z.ZodType<CommonTriggerBackendConfig> = CommonTriggerOptions;

--- a/common.ts
+++ b/common.ts
@@ -50,4 +50,4 @@ export const CommonAccountInjectionOptions: z.ZodObject<
 
 /** Common backend config for all trigger configurations */
 export type CommonTriggerBackendConfig = CommonTriggerOptions;
-export const CommonTriggerBackendConfig: z.ZodType<CommonTriggerBackendConfig> = CommonTriggerOptions;
+export const CommonTriggerBackendConfig: typeof CommonTriggerOptions = CommonTriggerOptions;

--- a/deno.json
+++ b/deno.json
@@ -7,14 +7,18 @@
     "./backendTypes": "./backendTypes.ts"
   },
   "tasks": {
-    "test": "deno test --allow-env=GLUE_DEV_PORT,GLUE_CLI_WS_ADDR --allow-net=127.0.0.1"
+    "test": "deno test --allow-env=GLUE_DEV_PORT,GLUE_CLI_WS_ADDR --allow-net=127.0.0.1",
+    "check": "deno check",
+    "lint": "deno lint",
+    "fmt": "deno fmt"
   },
   "imports": {
     "@octokit/webhooks-types": "npm:@octokit/webhooks-types@^7.6.1",
     "@std/assert": "jsr:@std/assert@1",
     "hono": "jsr:@hono/hono@^4.7.4",
     "stripe": "npm:stripe@^18.2.0",
-    "zod": "npm:zod@^3.24.2"
+    "zod": "npm:zod@^3.24.2",
+    "@slack/types": "npm:@slack/types@^2.14.0"
   },
   "fmt": {
     "lineWidth": 160

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@streak-glue/runtime",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -6,6 +6,7 @@
     "jsr:@std/internal@^1.0.5": "1.0.5",
     "npm:@octokit/webhooks-types@*": "7.6.1",
     "npm:@octokit/webhooks-types@^7.6.1": "7.6.1",
+    "npm:@slack/types@^2.14.0": "2.16.0",
     "npm:@types/node@*": "22.12.0",
     "npm:octokit@*": "4.1.2_@octokit+core@6.1.4",
     "npm:stripe@*": "18.1.1_@types+node@22.12.0",
@@ -221,6 +222,9 @@
         "@octokit/request-error",
         "@octokit/webhooks-methods"
       ]
+    },
+    "@slack/types@2.16.0": {
+      "integrity": "sha512-bICnyukvdklXhwxprR3uF1+ZFkTvWTZge4evlCS4G1H1HU6QLY68AcjqzQRymf7/5gNt6Y4OBb4NdviheyZcAg=="
     },
     "@types/aws-lambda@8.10.148": {
       "integrity": "sha512-JL+2cfkY9ODQeE06hOxSFNkafjNk4JRBgY837kpoq1GHDttq2U3BA9IzKOWxS4DLjKoymGB4i9uBrlCkjUl1yg=="
@@ -515,6 +519,7 @@
       "jsr:@hono/hono@^4.7.4",
       "jsr:@std/assert@1",
       "npm:@octokit/webhooks-types@^7.6.1",
+      "npm:@slack/types@^2.14.0",
       "npm:stripe@^18.2.0",
       "npm:zod@^3.24.2"
     ]

--- a/integrations/cron/runtime.ts
+++ b/integrations/cron/runtime.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CommonTriggerOptions } from "../../common.ts";
+import { type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 import { registerEventListener } from "../../runtimeSupport.ts";
 
-export interface CronTriggerBackendConfig extends CommonTriggerOptions {
+export interface CronTriggerBackendConfig extends CommonTriggerBackendConfig {
   /** The cron expression defining when the event should trigger */
   crontab: string;
 }

--- a/integrations/github/runtime.ts
+++ b/integrations/github/runtime.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { WebhookEventMap, WebhookEventName } from "@octokit/webhooks-types";
 import { registerEventListener } from "../../runtimeSupport.ts";
-import { CommonTriggerOptions } from "../../common.ts";
+import { type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 
 /**
  * Options specific to GitHub event triggers.
@@ -19,7 +19,7 @@ export interface GithubTriggerOptions extends CommonTriggerOptions {
  * Configuration for listening to events on a specific GitHub repository.
  * @internal
  */
-interface GithubRepoTriggerBackendConfig extends CommonTriggerOptions {
+interface GithubRepoTriggerBackendConfig extends CommonTriggerBackendConfig {
   /** The owner (user or organization) of the repository */
   owner: string;
   /** The name of the repository */
@@ -41,7 +41,7 @@ const GithubRepoTriggerBackendConfig: z.ZodType<GithubRepoTriggerBackendConfig> 
  * Configuration for listening to events on a GitHub organization.
  * @internal
  */
-interface GithubOrgTriggerBackendConfig extends CommonTriggerOptions {
+interface GithubOrgTriggerBackendConfig extends CommonTriggerBackendConfig {
   /** The organization name */
   org: string;
   /** Array of GitHub webhook event names to listen for */

--- a/integrations/intercom/runtime.ts
+++ b/integrations/intercom/runtime.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { CommonTriggerOptions } from "../../common.ts";
+import { type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 import { registerEventListener } from "../../runtimeSupport.ts";
 
 export interface IntercomTriggerOptions extends CommonTriggerOptions {
@@ -60,7 +60,7 @@ export interface IntercomEvent {
   workspaceId: string;
 }
 
-export interface IntercomTriggerBackendConfig extends CommonTriggerOptions {
+export interface IntercomTriggerBackendConfig extends CommonTriggerBackendConfig {
   /** Array of Intercom event topics to listen for */
   events: string[];
   /** Optional workspace ID filter */

--- a/integrations/slack/runtime.ts
+++ b/integrations/slack/runtime.ts
@@ -1,0 +1,179 @@
+import z from "zod";
+import { type CommonAccountInjectionOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
+import { type AccessTokenCredential, type AccountFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
+import type { SlackEvent } from "@slack/types";
+
+/** Various types of events from Slack */
+export type SlackEventType = SlackEvent["type"];
+
+/** The webhook payload from Slack for all events */
+export type SlackEventWebhook = {
+  type: "event_callback";
+  event: SlackEvent;
+  team_id: string;
+  event_id: string;
+  event_context: string;
+  event_time: number;
+  channel?: string;
+  authorizations: {
+    team_id: string;
+    user_id: string;
+  }[];
+};
+
+/** The webhook payload from Slack for all events */
+export const SlackEventWebhook: z.ZodType<SlackEventWebhook> = z.object({
+  type: z.literal("event_callback"),
+  event: z.custom<SlackEvent>(),
+  team_id: z.string(),
+  event_id: z.string(),
+  event_context: z.string(),
+  event_time: z.number(),
+  channel: z.string().optional(),
+  authorizations: z.array(z.object({
+    team_id: z.string(),
+    user_id: z.string(),
+  })),
+});
+
+export interface SlackTriggerOptions extends CommonTriggerOptions {
+  /**
+   * The team ID or workspace to listen for events on
+   */
+  teamId?: string;
+
+  /**
+   * The channel ID to filter events on. If not provided, all channels will be listened to.
+   */
+  channelId?: string;
+}
+
+export interface SlackTriggerBackendConfig extends CommonTriggerBackendConfig {
+  /** The team ID or workspace to listen for events on */
+  teamId?: string;
+  /** Array of user events to listen for */
+  events: SlackEventType[];
+  /** Optional channel IDs to filter events */
+  channels?: string[];
+}
+export const SlackTriggerBackendConfig: z.ZodType<SlackTriggerBackendConfig> = CommonTriggerOptions.extend({
+  teamId: z.string().optional(),
+  events: z.array(z.custom<SlackEventType>()),
+  channels: z.array(z.string()).optional(),
+});
+
+interface SlackCredentialFetcherOptions extends CommonAccountInjectionOptions {
+  scopes: string[];
+  teamId?: string;
+}
+
+/**
+ * Slack event source for all slack events.
+ *
+ * Provides methods to register glue handlers for Slack webhook events,
+ * allowing you to react to new messages, new channels, new users, etc.
+ *
+ * @example
+ * ```typescript
+ * // Monitor closed conversations
+ * glue.slack.onNewUserVisibleMessage((webhook) => {
+ *   const msg = webhook.event.text;
+ *   console.log(msg);
+ * });
+ *
+ * // Listen for multiple event types
+ * glue.slack.onUserEvents([
+ *   "message",
+ *   "channel_created"
+ * ], (webhook) => {
+ *   if (webhook.event.type === "channel_created") {
+ *     console.log(webhook.event.channel);
+ *   } else {
+ *     console.log(webhook.event.text);
+ *   }
+ * });
+ * ```
+ */
+export class Slack {
+  /**
+   * Registers a glue handler for specific Slack webhook events.
+   *
+   * This is the most flexible method, allowing you to listen for any
+   * combination of Slack event topics.
+   *
+   * @param events - Array of Slack event topics to listen for
+   * @param fn - Handler function called when any of the specified events occur
+   * @param options - Optional trigger configuration including workspace filtering
+   *
+   * @example
+   * ```typescript
+   * // Listen for conversation events
+   * glue.slack.onEvent([
+   *   "message",
+   *   "channel_created"
+   * ], (webhook) => {
+   *   switch (webhook.event.type) {
+   *     case "message":
+   *       console.log(webhook.event.text);
+   *       break;
+   *     case "channel_created":
+   *       console.log(webhook.event.channel);
+   *       break;
+   *   }
+   * });
+   * ```
+   *
+   * @see https://docs.slack.dev/reference/events - Full list of event types
+   */
+  onEvents(events: SlackEventType[], fn: (event: SlackEventWebhook) => void, options?: SlackTriggerOptions): void {
+    const config: SlackTriggerBackendConfig = {
+      ...options,
+      events: events,
+      teamId: options?.teamId,
+      channels: undefined,
+    };
+    registerEventListener("slack", fn, config);
+  }
+
+  /**
+   * Registers a glue handler for new user visible messages.
+   *
+   * Triggered when a message is posted to a channel visible to the user.
+   */
+  onNewMessage(
+    fn: (event: SlackEventWebhook) => void,
+    options?: SlackTriggerOptions,
+  ): void {
+    this.onEvents(["message"], fn, options);
+  }
+
+  createUserCredentialFetcher(options: SlackCredentialFetcherOptions): AccountFetcher<AccessTokenCredential> {
+    return registerAccountInjection<AccessTokenCredential>("slack", {
+      description: options.description,
+      selector: options.teamId,
+      scopes: options.scopes,
+    });
+  }
+
+  createBotCredentialFetcher(options: SlackCredentialFetcherOptions): AccountFetcher<AccessTokenCredential> {
+    return registerAccountInjection<AccessTokenCredential>("slackBot", {
+      description: options.description,
+      selector: options.teamId,
+      scopes: options.scopes,
+    });
+  }
+
+  createUserMessageSendingCredentialFetcher(options?: Omit<SlackCredentialFetcherOptions, "scopes">): AccountFetcher<AccessTokenCredential> {
+    return this.createUserCredentialFetcher({
+      ...options,
+      scopes: ["chat:write"],
+    });
+  }
+
+  createBotMessageSendingCredentialFetcher(options?: Omit<SlackCredentialFetcherOptions, "scopes">): AccountFetcher<AccessTokenCredential> {
+    return this.createBotCredentialFetcher({
+      ...options,
+      scopes: ["chat:write", "chat:write.customize"],
+    });
+  }
+}

--- a/integrations/slack/runtime.ts
+++ b/integrations/slack/runtime.ts
@@ -37,14 +37,10 @@ export const SlackEventWebhook: z.ZodType<SlackEventWebhook> = z.object({
 });
 
 export interface SlackTriggerOptions extends CommonTriggerOptions {
-  /**
-   * The team ID or workspace to listen for events on
-   */
+  /** Optional team ID or workspace to listen for events on */
   teamId?: string;
 
-  /**
-   * The channel ID to filter events on. If not provided, all channels will be listened to.
-   */
+  /** Optional channel ID to filter events on. If provided, only events from this channel will be listened to.  */
   channelId?: string;
 }
 
@@ -62,7 +58,7 @@ export const SlackTriggerBackendConfig: z.ZodType<SlackTriggerBackendConfig> = C
   channels: z.array(z.string()).optional(),
 });
 
-interface SlackCredentialFetcherOptions extends CommonAccountInjectionOptions {
+export interface SlackCredentialFetcherOptions extends CommonAccountInjectionOptions {
   scopes: string[];
   teamId?: string;
 }

--- a/integrations/streak/runtime.ts
+++ b/integrations/streak/runtime.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { type CommonAccountInjectionOptions, CommonTriggerOptions } from "../../common.ts";
+import { type CommonAccountInjectionOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 import { type AccountFetcher, type ApiKeyCredential, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
 
 /**
@@ -12,7 +12,7 @@ export interface StreakTriggerOptions extends CommonTriggerOptions {
   emailAddress?: string;
 }
 
-export interface StreakTriggerBackendConfig extends CommonTriggerOptions {
+export interface StreakTriggerBackendConfig extends CommonTriggerBackendConfig {
   /** The Streak pipeline key to monitor for events */
   pipelineKey: string;
   /** The specific box event type to listen for */

--- a/integrations/stripe/runtime.ts
+++ b/integrations/stripe/runtime.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import type { Stripe as StripeLib } from "stripe";
 import { registerEventListener } from "../../runtimeSupport.ts";
-import { CommonTriggerOptions } from "../../common.ts";
+import { type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 
 /**
  * Union type of all possible Stripe webhook event types.
@@ -20,7 +20,7 @@ export interface StripeTriggerOptions extends CommonTriggerOptions {
   accountLabel?: string;
 }
 
-export interface StripeTriggerBackendConfig extends CommonTriggerOptions {
+export interface StripeTriggerBackendConfig extends CommonTriggerBackendConfig {
   /** Array of Stripe event types to listen for */
   events: StripeEventType[];
   /** Optional account label for the account */

--- a/mod.ts
+++ b/mod.ts
@@ -5,7 +5,7 @@
  *
  * This package provides a unified interface for listening to events from various external services
  * and platforms. It allows developers to easily build reactive applications that respond to events
- * from GitHub, Gmail, webhooks, cron schedules, Stripe, Intercom, Webflow, and Streak.
+ * from GitHub, Gmail, webhooks, cron schedules, Stripe, Intercom, Webflow, Slack, and Streak.
  *
  * ## Overview
  *
@@ -42,6 +42,7 @@
  * - **Cron**: Scheduled tasks using cron expressions
  * - **Stripe**: Payment and subscription events
  * - **Intercom**: Customer conversation events
+ * - **Slack**: Slack events
  * - **Webflow**: Website and CMS events
  * - **Streak**: CRM pipeline and box events
  *
@@ -56,6 +57,7 @@ import * as streakEventSource from "./integrations/streak/runtime.ts";
 import * as stripeEventSource from "./integrations/stripe/runtime.ts";
 import * as cronEventSource from "./integrations/cron/runtime.ts";
 import * as intercomEventSource from "./integrations/intercom/runtime.ts";
+import * as slackEventSource from "./integrations/slack/runtime.ts";
 import { Debug } from "./integrations/debug/runtime.ts";
 export type { GoogleAccountInjectionOptions } from "./integrations/google/runtime.ts";
 export type { GmailMessageEvent, GmailTriggerOptions } from "./integrations/gmail/runtime.ts";
@@ -65,6 +67,7 @@ export type { CronEvent } from "./integrations/cron/runtime.ts";
 export type { BoxEventType, StreakAccountInjectionOptions, StreakEvent, StreakTriggerOptions } from "./integrations/streak/runtime.ts";
 export type { StripeEvent, StripeTriggerOptions } from "./integrations/stripe/runtime.ts";
 export type { IntercomEvent, IntercomTriggerOptions } from "./integrations/intercom/runtime.ts";
+export type { SlackEventWebhook, SlackTriggerOptions } from "./integrations/slack/runtime.ts";
 export type { AccessTokenCredential, AccountFetcher, ApiKeyCredential } from "./runtimeSupport.ts";
 export type { CommonAccountInjectionOptions, CommonTriggerOptions } from "./common.ts";
 
@@ -122,6 +125,12 @@ class Glue {
    * Tracks events in Intercom workspaces like conversation closures.
    */
   readonly intercom: intercomEventSource.Intercom = new intercomEventSource.Intercom();
+
+  /**
+   * Slack event source for all Slack events.
+   * Tracks events in Slack workspaces like messages, channels, users, etc.
+   */
+  readonly slack: slackEventSource.Slack = new slackEventSource.Slack();
 
   /**
    * Debug utilities exposing low-level registration helpers.

--- a/mod.ts
+++ b/mod.ts
@@ -67,7 +67,7 @@ export type { CronEvent } from "./integrations/cron/runtime.ts";
 export type { BoxEventType, StreakAccountInjectionOptions, StreakEvent, StreakTriggerOptions } from "./integrations/streak/runtime.ts";
 export type { StripeEvent, StripeTriggerOptions } from "./integrations/stripe/runtime.ts";
 export type { IntercomEvent, IntercomTriggerOptions } from "./integrations/intercom/runtime.ts";
-export type { SlackEventWebhook, SlackTriggerOptions } from "./integrations/slack/runtime.ts";
+export type { SlackCredentialFetcherOptions, SlackEventWebhook, SlackTriggerOptions } from "./integrations/slack/runtime.ts";
 export type { AccessTokenCredential, AccountFetcher, ApiKeyCredential } from "./runtimeSupport.ts";
 export type { CommonAccountInjectionOptions, CommonTriggerOptions } from "./common.ts";
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-16 22:04:38 UTC

### Greptile Summary

This PR introduces Slack integration support to the glue-runtime framework by adding a new Slack event source with comprehensive webhook event handling, user/bot credential management, and filtering capabilities. The changes follow the established architectural pattern used by other integrations in the codebase (GitHub, Gmail, Stripe, etc.) and include a new `integrations/slack/runtime.ts` module that provides a Slack class with methods for listening to workspace events and managing authentication scopes.

The PR also implements a broader architectural refactoring across all integration modules by introducing `CommonTriggerBackendConfig` as a separate type from `CommonTriggerOptions`. This establishes cleaner separation between user-facing trigger configuration options and internal backend configuration structures, improving type safety and maintainability. All existing integrations (cron, github, intercom, slack, streak, stripe) are updated to use this new backend configuration pattern while maintaining API compatibility.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|--------|-----------|
| integrations/slack/runtime.ts | 3/5 | New comprehensive Slack integration with webhook handling, credential management, and event filtering - has schema inconsistencies and documentation errors |
| integrations/intercom/runtime.ts | 2/5 | Updates interface to use CommonTriggerBackendConfig but has critical Zod schema mismatch that will cause runtime validation failures |
| common.ts | 5/5 | Adds new CommonTriggerBackendConfig type alias to separate backend config from frontend options - safe architectural improvement |
| mod.ts | 5/5 | Adds Slack integration to main Glue class following established pattern with proper imports and exports |
| deno.json | 5/5 | Adds @slack/types dependency and development tasks for Slack integration support |
| backendTypes.ts | 5/5 | Exports Slack backend configuration types following established pattern |
| integrations/github/runtime.ts | 5/5 | Updates to use CommonTriggerBackendConfig for better type separation - maintains all functionality |
| integrations/cron/runtime.ts | 5/5 | Updates to use CommonTriggerBackendConfig interface for improved type consistency |
| integrations/streak/runtime.ts | 5/5 | Updates to use CommonTriggerBackendConfig as part of architectural refactoring |
| integrations/stripe/runtime.ts | 5/5 | Updates to use CommonTriggerBackendConfig for consistent backend configuration structure |
| README.md | 4/5 | Adds Slack documentation section but contains placeholder TODO content indicating incomplete implementation |

</details>

### Confidence score: 2/5

- This PR requires careful review due to critical validation errors and documentation inconsistencies in the Slack integration
- Score lowered due to schema mismatch in intercom integration causing potential runtime failures, Zod validation bypass in Slack module allowing invalid data, incorrect JSDoc documentation, and logic errors in event filtering
- Pay close attention to integrations/intercom/runtime.ts and integrations/slack/runtime.ts which both contain validation issues that could cause production failures

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - .cursor/rules/read-readme.mdc ([source](https://app.greptile.com/review/custom-context?memory=5b5fc9fd-0cd6-4879-b20d-97003e705fd2))

<!-- /greptile_comment -->