### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # glue-runtime
 
-A comprehensive event-driven runtime for building serverless integrations with external services.
-
-## Overview
-
-Glue Runtime provides a unified interface for listening to events from various external services and platforms. It allows developers to easily build reactive
-applications that respond to events from GitHub, Gmail, webhooks, cron schedules, Stripe, Intercom, Webflow, and Streak.
+This library contains the APIs for Glue scripts to connect to various services and integrations including GitHub, Gmail, webhooks, cron schedules, Stripe,
+Intercom, Webflow, and Streak. Events from these integrations can trigger your Glue scripts to perform automated tasks.
 
 ## Installation
 
@@ -222,26 +218,7 @@ glue.github.onPullRequestEvent("owner", "repo", handlePR, {
 });
 ```
 
-## Event Types
-
-All event types are fully typed with TypeScript, providing excellent IDE support and type safety:
-
-- `GithubEvent<T>` - GitHub webhook events
-- `GmailMessageEvent` - Gmail new message events
-- `WebhookEvent` - HTTP webhook requests
-- `CronEvent` - Scheduled task triggers
-- `StripeEvent<T>` - Stripe webhook events
-- `IntercomEvent` - Intercom webhook events
-- `SlackEventWebhook` - Slack webhook events
-- `WebflowEvent<T>` - Webflow webhook events
-- `StreakEvent` - Streak CRM events
-
 ## Important Notes
 
-1. **Registration Timing**: All event handlers must be registered at the top level of your application during initialization. You cannot register handlers
-   dynamically after the application has started.
-
-2. **Type Safety**: The package provides full TypeScript support with type inference for event payloads based on the event type.
-
-3. **Error Handling**: Errors thrown in event handlers are automatically caught and logged. The runtime continues processing other events even if one handler
-   fails.
+- **Registration Timing**: All event handlers must be registered at the top level of your application during initialization. You cannot register handlers
+  dynamically after the application has started.

--- a/backendTypes.ts
+++ b/backendTypes.ts
@@ -63,8 +63,8 @@ export const AccountInjectionBackendConfig: z.ZodType<AccountInjectionBackendCon
 export interface AccountInjectionRegistration {
   type: string;
   /**
-   * The unique label identifying the specific account injection within the glue
-   * deployment.
+   * The unique label identifying the specific credential fetcher within the
+   * glue deployment.
    */
   label: string;
   config: AccountInjectionBackendConfig;
@@ -84,7 +84,7 @@ export const AccountInjectionRegistration: z.ZodType<AccountInjectionRegistratio
 export interface Registrations {
   /** All event trigger registrations in the application */
   triggers: TriggerRegistration[];
-  /** All account injection registrations in the application */
+  /** All credential fetcher registrations in the application */
   accountInjections: AccountInjectionRegistration[];
 }
 
@@ -96,13 +96,13 @@ export const Registrations: z.ZodType<Registrations> = z.object({
 
 export type { CommonAccountInjectionOptions, CommonTriggerOptions } from "./common.ts";
 
-/** Represents an account injection credential using an access token */
+/** Represents a credential using an access token */
 export interface AccessTokenCredential {
   accessToken: string;
   expiresAt?: number;
 }
 
-/** Represents an account injection credential using an API key */
+/** Represents a credential using an API key */
 export interface ApiKeyCredential {
   apiKey: string;
 }

--- a/backendTypes.ts
+++ b/backendTypes.ts
@@ -1,14 +1,8 @@
 /**
- * @module
+ * Internal types shared between the Glue runtime and the backend API. These
+ * types are not intended for most Glue users to use.
  *
- * Internal types shared between the Glue runtime and the CLI/backend.
- *
- * This module contains the core type definitions used for event registration,
- * trigger configuration, and account injection throughout the Glue system.
- * These types ensure consistency between the runtime library and the backend
- * services that process and execute the registered triggers. These types should
- * not be needed by users creating Glues, its only for internal (to Glue) use.
- * @internal
+ * @module @internal
  */
 
 import { z } from "zod";

--- a/common.ts
+++ b/common.ts
@@ -24,10 +24,10 @@ export const CommonTriggerOptions: z.ZodObject<
 });
 
 /**
- * Common options available for all account injection configurations.
+ * Common options available for all credential fetcher configurations.
  */
 export interface CommonAccountInjectionOptions {
-  /** Description that appears for the account injection when configuring a Glue. */
+  /** Description that appears for the credential fetcher when configuring a Glue. */
   description?: string;
 }
 

--- a/integrations/debug/runtime.ts
+++ b/integrations/debug/runtime.ts
@@ -1,11 +1,3 @@
-/**
- * Debug integration exposing low-level registration helpers.
- *
- * These APIs are intentionally unstable and primarily meant for internal
- * experimentation and tests. They allow registering arbitrary trigger types
- * and account injections without the usual type-safe wrappers provided by
- * first-class integrations.
- */
 import {
   type AccessTokenCredential,
   type ApiKeyCredential,
@@ -16,6 +8,15 @@ import {
 import type { AccountInjectionBackendConfig } from "../../backendTypes.ts";
 import type { CommonTriggerOptions } from "../../common.ts";
 
+/**
+ * Debug integration exposing low-level registration helpers.
+ *
+ * These APIs are intentionally unstable and primarily meant for internal
+ * experimentation and tests. They allow registering arbitrary trigger types and
+ * credential fetchers without going through the usual type-safe wrappers.
+ *
+ * @internal
+ */
 export class Debug {
   /**
    * Register a raw trigger with an arbitrary type string and config object.

--- a/integrations/debug/runtime.ts
+++ b/integrations/debug/runtime.ts
@@ -34,7 +34,7 @@ export class Debug {
   }
 
   /**
-   * Register a raw account injection for an arbitrary integration type.
+   * Register a raw credential fetcher for an arbitrary integration type.
    *
    * NOTE: This must be called at module top-level before the event loop turns
    * (consistent with all other registrations) otherwise an error will be thrown

--- a/integrations/debug/runtime.ts
+++ b/integrations/debug/runtime.ts
@@ -8,8 +8,8 @@
  */
 import {
   type AccessTokenCredential,
-  type AccountFetcher,
   type ApiKeyCredential,
+  type CredentialFetcher,
   registerAccountInjection,
   registerEventListener,
 } from "../../runtimeSupport.ts";
@@ -43,7 +43,7 @@ export class Debug {
   registerRawAccountInjection<T extends AccessTokenCredential | ApiKeyCredential>(
     type: string,
     config: AccountInjectionBackendConfig,
-  ): AccountFetcher<T> {
+  ): CredentialFetcher<T> {
     return registerAccountInjection<T>(type, config);
   }
 }

--- a/integrations/github/runtime.ts
+++ b/integrations/github/runtime.ts
@@ -64,9 +64,7 @@ export const GithubTriggerBackendConfig: z.ZodType<GithubTriggerBackendConfig> =
 ]);
 
 /**
- * Options specific to GitHub account injections.
- *
- * Extends the common account injection options with GitHub-specific configuration.
+ * Options for GitHub credential fetchers.
  */
 export interface GithubAccountInjectionOptions extends CommonAccountInjectionOptions {
   /**

--- a/integrations/github/runtime.ts
+++ b/integrations/github/runtime.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { WebhookEventMap, WebhookEventName } from "@octokit/webhooks-types";
-import { type AccessTokenCredential, type AccountFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
+import { type AccessTokenCredential, type CredentialFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
 import { type CommonAccountInjectionOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 
 /**
@@ -273,7 +273,7 @@ export class Github {
    * });
    * ```
    */
-  createCredentialFetcher(options: GithubAccountInjectionOptions): AccountFetcher<AccessTokenCredential> {
+  createCredentialFetcher(options: GithubAccountInjectionOptions): CredentialFetcher<AccessTokenCredential> {
     return registerAccountInjection<AccessTokenCredential>("github", {
       description: options.description,
       selector: options.username,

--- a/integrations/google/runtime.ts
+++ b/integrations/google/runtime.ts
@@ -1,5 +1,5 @@
 import type { CommonAccountInjectionOptions } from "../../common.ts";
-import { type AccessTokenCredential, type AccountFetcher, registerAccountInjection } from "../../runtimeSupport.ts";
+import { type AccessTokenCredential, type CredentialFetcher, registerAccountInjection } from "../../runtimeSupport.ts";
 
 export interface GoogleAccountInjectionOptions extends CommonAccountInjectionOptions {
   /**
@@ -34,7 +34,7 @@ export class Google {
    * });
    * ```
    */
-  createCredentialFetcher(options: GoogleAccountInjectionOptions): AccountFetcher<AccessTokenCredential> {
+  createCredentialFetcher(options: GoogleAccountInjectionOptions): CredentialFetcher<AccessTokenCredential> {
     return registerAccountInjection<AccessTokenCredential>("google", {
       description: options.description,
       selector: options.accountEmailAddress,

--- a/integrations/resend/runtime.ts
+++ b/integrations/resend/runtime.ts
@@ -1,5 +1,5 @@
 import type { CommonAccountInjectionOptions } from "../../common.ts";
-import { type AccountFetcher, type ApiKeyCredential, registerAccountInjection } from "../../runtimeSupport.ts";
+import { type ApiKeyCredential, type CredentialFetcher, registerAccountInjection } from "../../runtimeSupport.ts";
 
 export interface ResendAccountInjectionOptions extends CommonAccountInjectionOptions {
   /** Optional API key name to select appropriate api key. */
@@ -30,7 +30,7 @@ export interface ResendAccountInjectionOptions extends CommonAccountInjectionOpt
  * @see https://resend.com/docs/api-reference
  */
 export class Resend {
-  createCredentialFetcher(options?: ResendAccountInjectionOptions): AccountFetcher<ApiKeyCredential> {
+  createCredentialFetcher(options?: ResendAccountInjectionOptions): CredentialFetcher<ApiKeyCredential> {
     return registerAccountInjection<ApiKeyCredential>("resend", {
       description: options?.description,
       selector: options?.apiKeyName,

--- a/integrations/slack/runtime.ts
+++ b/integrations/slack/runtime.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { type CommonAccountInjectionOptions, CommonTriggerBackendConfig, type CommonTriggerOptions } from "../../common.ts";
-import { type AccessTokenCredential, type AccountFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
+import { type AccessTokenCredential, type CredentialFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
 import type { AllMessageEvents, GenericMessageEvent, SlackEvent } from "@slack/types";
 import { type ChatPostMessageResponse, ErrorCode, type WebAPIPlatformError, WebClient } from "@slack/web-api";
 
@@ -170,7 +170,7 @@ export class Slack {
    * });
    * ```
    */
-  createUserCredentialFetcher(options: SlackCredentialFetcherOptions): AccountFetcher<AccessTokenCredential> {
+  createUserCredentialFetcher(options: SlackCredentialFetcherOptions): CredentialFetcher<AccessTokenCredential> {
     return registerAccountInjection<AccessTokenCredential>("slack", {
       description: options.description,
       selector: options.teamId,
@@ -199,7 +199,7 @@ export class Slack {
    * });
    * ```
    */
-  createBotCredentialFetcher(options: SlackCredentialFetcherOptions): AccountFetcher<AccessTokenCredential> {
+  createBotCredentialFetcher(options: SlackCredentialFetcherOptions): CredentialFetcher<AccessTokenCredential> {
     return registerAccountInjection<AccessTokenCredential>("slackBot", {
       description: options.description,
       selector: options.teamId,
@@ -227,7 +227,7 @@ export class Slack {
    * });
    * ```
    */
-  createUserMessageSendingCredentialFetcher(options?: Omit<SlackCredentialFetcherOptions, "scopes">): AccountFetcher<AccessTokenCredential> {
+  createUserMessageSendingCredentialFetcher(options?: Omit<SlackCredentialFetcherOptions, "scopes">): CredentialFetcher<AccessTokenCredential> {
     return this.createUserCredentialFetcher({
       ...options,
       scopes: ["chat:write"],
@@ -254,7 +254,7 @@ export class Slack {
    * });
    * ```
    */
-  createBotMessageSendingCredentialFetcher(options?: Omit<SlackCredentialFetcherOptions, "scopes">): AccountFetcher<AccessTokenCredential> {
+  createBotMessageSendingCredentialFetcher(options?: Omit<SlackCredentialFetcherOptions, "scopes">): CredentialFetcher<AccessTokenCredential> {
     return this.createBotCredentialFetcher({
       ...options,
       scopes: [
@@ -282,7 +282,7 @@ export class Slack {
    * @param threadTs The parent of the message you want to send. Used when you want to thread messages.
    */
   async sendMessageAsBot(
-    credentialFetcher: AccountFetcher<AccessTokenCredential>,
+    credentialFetcher: CredentialFetcher<AccessTokenCredential>,
     channelId: string,
     text: string,
     threadTs?: string,

--- a/integrations/streak/runtime.ts
+++ b/integrations/streak/runtime.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { type CommonAccountInjectionOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
-import { type AccountFetcher, type ApiKeyCredential, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
+import { type ApiKeyCredential, type CredentialFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
 
 /**
  * Options specific to Streak event triggers.
@@ -143,7 +143,7 @@ export class Streak {
     this.onBoxEvent("BOX_CHANGE_STAGE", pipelineKey, fn, options);
   }
 
-  createCredentialFetcher(options?: StreakAccountInjectionOptions): AccountFetcher<ApiKeyCredential> {
+  createCredentialFetcher(options?: StreakAccountInjectionOptions): CredentialFetcher<ApiKeyCredential> {
     return registerAccountInjection<ApiKeyCredential>("streak", {
       description: options?.description,
       selector: options?.emailAddress,

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -20,7 +20,7 @@ Deno.test({
       callCount++;
       console.log("debug callback");
     }, { custom: 123 });
-    const _testAccountFetcher = glue.debug.registerRawAccountInjection("testAccount", { scopes: ["foo"] });
+    const _testCredentialFetcher = glue.debug.registerRawAccountInjection("testAccount", { scopes: ["foo"] });
 
     await Promise.resolve();
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,65 +1,24 @@
-/**
- * @module
- *
- * Glue Runtime - A comprehensive event-driven runtime for building serverless integrations
- *
- * This package provides a unified interface for listening to events from various external services
- * and platforms. It allows developers to easily build reactive applications that respond to events
- * from GitHub, Gmail, webhooks, cron schedules, Stripe, Intercom, Webflow, Slack, and Streak.
- *
- * ## Overview
- *
- * The Glue runtime operates by registering event listeners that are triggered when specific events
- * occur in connected services. Each event source provides type-safe event handlers with full
- * TypeScript support.
- *
- * ## Basic Usage
- *
- * ```typescript
- * import { glue } from "@glue/runtime";
- *
- * // Listen for GitHub pull request events
- * glue.github.onPullRequestEvent("owner", "repo", (event) => {
- *   console.log("New PR:", event.payload.pull_request.title);
- * });
- *
- * // Schedule a cron job
- * glue.cron.everyXMinutes(5, () => {
- *   console.log("Running every 5 minutes");
- * });
- *
- * // Handle webhook requests
- * glue.webhook.onPost((event) => {
- *   console.log("Received POST:", event.bodyText);
- * });
- * ```
- *
- * ## Event Sources
- *
- * - **GitHub**: Repository and organization events (pull requests, issues, pushes, etc.)
- * - **Gmail**: Email message events
- * - **Webhook**: HTTP webhook endpoints (GET, POST, etc.)
- * - **Cron**: Scheduled tasks using cron expressions
- * - **Stripe**: Payment and subscription events
- * - **Intercom**: Customer conversation events
- * - **Slack**: Slack events
- * - **Webflow**: Website and CMS events
- * - **Streak**: CRM pipeline and box events
- *
- * All event handlers must be registered at the top level of your application during initialization.
- */
-
 import { Google } from "./integrations/google/runtime.ts";
-import * as gmailEventSource from "./integrations/gmail/runtime.ts";
-import * as webhookEventSource from "./integrations/webhook/runtime.ts";
-import * as githubEventSource from "./integrations/github/runtime.ts";
-import * as streakEventSource from "./integrations/streak/runtime.ts";
-import * as stripeEventSource from "./integrations/stripe/runtime.ts";
+export type { Google };
+import { Gmail } from "./integrations/gmail/runtime.ts";
+export type { Gmail };
+import { Webhook } from "./integrations/webhook/runtime.ts";
+export type { Webhook };
+import { Github } from "./integrations/github/runtime.ts";
+export type { Github };
+import { Streak } from "./integrations/streak/runtime.ts";
+export type { Streak };
+import { Stripe } from "./integrations/stripe/runtime.ts";
+export type { Stripe };
 import * as cronEventSource from "./integrations/cron/runtime.ts";
-import * as intercomEventSource from "./integrations/intercom/runtime.ts";
-import * as slackEventSource from "./integrations/slack/runtime.ts";
-import * as resendEventSource from "./integrations/resend/runtime.ts";
+import { Intercom } from "./integrations/intercom/runtime.ts";
+export type { Intercom };
+import { Slack } from "./integrations/slack/runtime.ts";
+export type { Slack };
+import { Resend } from "./integrations/resend/runtime.ts";
+export type { Resend };
 import { Debug } from "./integrations/debug/runtime.ts";
+export type { Debug };
 export type { GoogleAccountInjectionOptions } from "./integrations/google/runtime.ts";
 export type { GmailMessageEvent, GmailTriggerOptions } from "./integrations/gmail/runtime.ts";
 export type { GithubEvent, GithubTriggerOptions } from "./integrations/github/runtime.ts";
@@ -87,7 +46,7 @@ class Glue {
    * Gmail event source for listening to email events.
    * Allows you to react to new emails in connected Gmail accounts.
    */
-  readonly gmail: gmailEventSource.Gmail = new gmailEventSource.Gmail();
+  readonly gmail: Gmail = new Gmail();
 
   readonly google: Google = new Google();
 
@@ -95,8 +54,7 @@ class Glue {
    * Webhook event source for handling HTTP webhook requests.
    * Creates endpoints that can receive HTTP requests from external services.
    */
-  readonly webhook: webhookEventSource.Webhook = new webhookEventSource
-    .Webhook();
+  readonly webhook: Webhook = new Webhook();
 
   /**
    * Cron event source for scheduling recurring tasks.
@@ -108,37 +66,37 @@ class Glue {
    * GitHub event source for repository and organization events.
    * Listens to GitHub webhooks for events like pull requests, issues, and pushes.
    */
-  readonly github: githubEventSource.Github = new githubEventSource.Github();
+  readonly github: Github = new Github();
 
   /**
    * Streak CRM event source for pipeline and box events.
    * Monitors changes in Streak CRM pipelines, boxes, tasks, and emails.
    */
-  readonly streak: streakEventSource.Streak = new streakEventSource.Streak();
+  readonly streak: Streak = new Streak();
 
   /**
    * Stripe event source for payment and subscription events.
    * Handles Stripe webhooks for customer, payment, and subscription lifecycle events.
    */
-  readonly stripe: stripeEventSource.Stripe = new stripeEventSource.Stripe();
+  readonly stripe: Stripe = new Stripe();
 
   /**
    * Intercom event source for customer conversation events.
    * Tracks events in Intercom workspaces like conversation closures.
    */
-  readonly intercom: intercomEventSource.Intercom = new intercomEventSource.Intercom();
+  readonly intercom: Intercom = new Intercom();
 
   /**
    * Slack event source for all Slack events.
    * Tracks events in Slack workspaces like messages, channels, users, etc.
    */
-  readonly slack: slackEventSource.Slack = new slackEventSource.Slack();
+  readonly slack: Slack = new Slack();
 
   /**
    * Resend event source for sending emails.
    * Sends emails using the Resend API.
    */
-  readonly resend: resendEventSource.Resend = new resendEventSource.Resend();
+  readonly resend: Resend = new Resend();
 
   /**
    * Debug utilities exposing low-level registration helpers.

--- a/mod.ts
+++ b/mod.ts
@@ -70,7 +70,7 @@ export type { StripeEvent, StripeTriggerOptions } from "./integrations/stripe/ru
 export type { IntercomEvent, IntercomTriggerOptions } from "./integrations/intercom/runtime.ts";
 export type { SlackCredentialFetcherOptions, SlackEventWebhook, SlackTriggerOptions } from "./integrations/slack/runtime.ts";
 export type { ResendAccountInjectionOptions } from "./integrations/resend/runtime.ts";
-export type { AccessTokenCredential, AccountFetcher, ApiKeyCredential } from "./runtimeSupport.ts";
+export type { AccessTokenCredential, ApiKeyCredential, CredentialFetcher } from "./runtimeSupport.ts";
 export type { CommonAccountInjectionOptions, CommonTriggerOptions } from "./common.ts";
 
 /**

--- a/runtimeSupport.ts
+++ b/runtimeSupport.ts
@@ -75,8 +75,8 @@ export interface CredentialFetcher<T> {
 
 /**
  * @internal
- * Registers an account injection for a specific service type.
- * This function is used internally by event source implementations.
+ * Registers a credential fetcher for a specific service type. This function is
+ * used internally by event source implementations.
  */
 export function registerAccountInjection<T extends AccessTokenCredential | ApiKeyCredential>(
   type: string,
@@ -92,7 +92,7 @@ export function registerAccountInjection<T extends AccessTokenCredential | ApiKe
   const resolvedLabel = String(nextAutomaticLabel++);
   if (typeAccountInjections.has(resolvedLabel)) {
     throw new Error(
-      `Account injection with label ${
+      `Credential fetcher with label ${
         JSON.stringify(
           resolvedLabel,
         )
@@ -127,7 +127,7 @@ export function registerAccountInjection<T extends AccessTokenCredential | ApiKe
       );
       if (!res.ok) {
         throw new Error(
-          `Failed to fetch account injection: ${res.status} ${res.statusText}`,
+          `Failed to fetch credential: ${res.status} ${res.statusText}`,
         );
       }
       const body = await res.json() as T;

--- a/runtimeSupport.ts
+++ b/runtimeSupport.ts
@@ -62,7 +62,7 @@ export function registerEventListener<T>(
 /**
  * Used to fetch an account credential or client at runtime.
  */
-export interface AccountFetcher<T> {
+export interface CredentialFetcher<T> {
   /**
    * Fetches the account credential or client. This must only be called within
    * an event handler.
@@ -81,7 +81,7 @@ export interface AccountFetcher<T> {
 export function registerAccountInjection<T extends AccessTokenCredential | ApiKeyCredential>(
   type: string,
   config: AccountInjectionBackendConfig,
-): AccountFetcher<T> {
+): CredentialFetcher<T> {
   scheduleInit();
   let typeAccountInjections = accountInjectionsByType.get(type);
   if (!typeAccountInjections) {


### PR DESCRIPTION
- All types referenced by the main `Glue` type are now exported so they're linkified correctly in the generated type docs.
- All references to "account injections" in docs are replaced with "credential fetchers". TODO rename the actual types that are named after account injections.
- Replaced or cut out some awkward AI-written docs.