### PR TITLE
Rename all type names with "account injection" to use "credential fetcher"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,6 @@
 This library contains the APIs for Glue scripts to connect to various services and integrations including GitHub, Gmail, webhooks, cron schedules, Stripe,
 Intercom, Webflow, and Streak. Events from these integrations can trigger your Glue scripts to perform automated tasks.
 
-## Installation
-
-```bash
-# Using Deno
-import { glue } from "jsr:@glue/runtime";
-```
-
 ## Quick Start
 
 ```typescript
@@ -40,7 +33,7 @@ glue dev myGlueFile.ts
 
 ### GitHub
 
-Monitor GitHub repositories and organizations for various events like pull requests, issues, pushes, and more.
+Monitor GitHub repositories and organizations for various events like pull requests, issues, pushed commits, and more.
 
 ```typescript
 // Listen for specific repository events
@@ -197,24 +190,9 @@ glue.streak.onBoxStageChanged("pipeline-key", (event) => {
 Monitor messages and channel activity
 
 ```typescript
-glue.slack.onUserVisibleMessage(); //TODO
-```
-
-## Common Options
-
-All event sources support common trigger options:
-
-```typescript
-interface CommonTriggerOptions {
-  label?: string; // Unique identifier for the trigger
-}
-```
-
-Example:
-
-```typescript
-glue.github.onPullRequestEvent("owner", "repo", handlePR, {
-  label: "pr-reviewer",
+glue.slack.onNewMessage((event) => {
+  const message = event.event;
+  console.log(`New message in ${message.channel}: ${message.text}`);
 });
 ```
 

--- a/backendTypes.ts
+++ b/backendTypes.ts
@@ -2,7 +2,8 @@
  * Internal types shared between the Glue runtime and the backend API. These
  * types are not intended for most Glue users to use.
  *
- * @module @internal
+ * @ignore
+ * @module
  */
 
 import { z } from "zod";

--- a/backendTypes.ts
+++ b/backendTypes.ts
@@ -7,7 +7,7 @@
  */
 
 import { z } from "zod";
-import { CommonAccountInjectionOptions } from "./common.ts";
+import { CommonCredentialFetcherOptions } from "./common.ts";
 
 export interface TriggerEvent {
   /** The event source type (e.g., "github", "stripe", "webhook") */
@@ -45,31 +45,31 @@ export const TriggerRegistration: z.ZodType<TriggerRegistration> = z.object({
   config: z.object({}).passthrough().optional(),
 });
 
-export interface AccountInjectionBackendConfig extends CommonAccountInjectionOptions {
+export interface CredentialFetcherBackendConfig extends CommonCredentialFetcherOptions {
   scopes?: string[];
   selector?: string;
 }
 
-export const AccountInjectionBackendConfig: z.ZodType<AccountInjectionBackendConfig> = CommonAccountInjectionOptions.extend({
+export const CredentialFetcherBackendConfig: z.ZodType<CredentialFetcherBackendConfig> = CommonCredentialFetcherOptions.extend({
   scopes: z.array(z.string()).optional(),
   selector: z.string().optional(),
 });
 
-export interface AccountInjectionRegistration {
+export interface CredentialFetcherRegistration {
   type: string;
   /**
    * The unique label identifying the specific credential fetcher within the
    * glue deployment.
    */
   label: string;
-  config: AccountInjectionBackendConfig;
+  config: CredentialFetcherBackendConfig;
 }
 
-export const AccountInjectionRegistration: z.ZodType<AccountInjectionRegistration> = z
+export const CredentialFetcherRegistration: z.ZodType<CredentialFetcherRegistration> = z
   .object({
     type: z.string(),
     label: z.string(),
-    config: AccountInjectionBackendConfig,
+    config: CredentialFetcherBackendConfig,
   });
 
 /**
@@ -80,16 +80,16 @@ export interface Registrations {
   /** All event trigger registrations in the application */
   triggers: TriggerRegistration[];
   /** All credential fetcher registrations in the application */
-  accountInjections: AccountInjectionRegistration[];
+  accountInjections: CredentialFetcherRegistration[];
 }
 
 export const Registrations: z.ZodType<Registrations> = z.object({
   triggers: z.array(TriggerRegistration),
-  accountInjections: z.array(AccountInjectionRegistration),
+  accountInjections: z.array(CredentialFetcherRegistration),
   // TODO secretInjections
 });
 
-export type { CommonAccountInjectionOptions, CommonTriggerOptions } from "./common.ts";
+export type { CommonCredentialFetcherOptions, CommonTriggerOptions } from "./common.ts";
 
 /** Represents a credential using an access token */
 export interface AccessTokenCredential {

--- a/common.ts
+++ b/common.ts
@@ -26,7 +26,7 @@ export const CommonTriggerOptions: z.ZodObject<
 /**
  * Common options available for all credential fetcher configurations.
  */
-export interface CommonAccountInjectionOptions {
+export interface CommonCredentialFetcherOptions {
   /** Description that appears for the credential fetcher when configuring a Glue. */
   description?: string;
 }
@@ -34,14 +34,14 @@ export interface CommonAccountInjectionOptions {
 // This needs this ugly explicit type because otherwise deno's
 // missing-explicit-type lint fails, and it needs to be a ZodObject type instead
 // of ZodType so the `.extend()` method is present.
-export const CommonAccountInjectionOptions: z.ZodObject<
+export const CommonCredentialFetcherOptions: z.ZodObject<
   {
     description: z.ZodOptional<z.ZodString>;
   },
   "strip",
   z.ZodTypeAny,
-  CommonAccountInjectionOptions,
-  CommonAccountInjectionOptions
+  CommonCredentialFetcherOptions,
+  CommonCredentialFetcherOptions
 > = z.object({
   description: z.string().optional(),
 });

--- a/deno.json
+++ b/deno.json
@@ -7,10 +7,17 @@
     "./backendTypes": "./backendTypes.ts"
   },
   "tasks": {
-    "test": "deno test --allow-sys --allow-env=GLUE_DEV_PORT,GLUE_CLI_WS_ADDR --allow-net=127.0.0.1",
+    "test": "deno test -P",
     "check": "deno check",
     "lint": "deno lint",
     "fmt": "deno fmt"
+  },
+  "test": {
+    "permissions": {
+      "sys": true,
+      "env": ["GLUE_DEV_PORT", "GLUE_CLI_WS_ADDR"],
+      "net": ["127.0.0.1"]
+    }
   },
   "imports": {
     "@octokit/webhooks-types": "npm:@octokit/webhooks-types@^7.6.1",

--- a/integrations/debug/runtime.ts
+++ b/integrations/debug/runtime.ts
@@ -2,10 +2,10 @@ import {
   type AccessTokenCredential,
   type ApiKeyCredential,
   type CredentialFetcher,
-  registerAccountInjection,
+  registerCredentialFetcher,
   registerEventListener,
 } from "../../runtimeSupport.ts";
-import type { AccountInjectionBackendConfig } from "../../backendTypes.ts";
+import type { CredentialFetcherBackendConfig } from "../../backendTypes.ts";
 import type { CommonTriggerOptions } from "../../common.ts";
 
 /**
@@ -41,10 +41,10 @@ export class Debug {
    * (consistent with all other registrations) otherwise an error will be thrown
    * by the runtime.
    */
-  registerRawAccountInjection<T extends AccessTokenCredential | ApiKeyCredential>(
+  registerRawCredentialFetcher<T extends AccessTokenCredential | ApiKeyCredential>(
     type: string,
-    config: AccountInjectionBackendConfig,
+    config: CredentialFetcherBackendConfig,
   ): CredentialFetcher<T> {
-    return registerAccountInjection<T>(type, config);
+    return registerCredentialFetcher<T>(type, config);
   }
 }

--- a/integrations/github/runtime.ts
+++ b/integrations/github/runtime.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { WebhookEventMap, WebhookEventName } from "@octokit/webhooks-types";
-import { type AccessTokenCredential, type CredentialFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
-import { type CommonAccountInjectionOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
+import { type AccessTokenCredential, type CredentialFetcher, registerCredentialFetcher, registerEventListener } from "../../runtimeSupport.ts";
+import { type CommonCredentialFetcherOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
 
 /**
  * Options specific to GitHub event triggers.
@@ -66,7 +66,7 @@ export const GithubTriggerBackendConfig: z.ZodType<GithubTriggerBackendConfig> =
 /**
  * Options for GitHub credential fetchers.
  */
-export interface GithubAccountInjectionOptions extends CommonAccountInjectionOptions {
+export interface GithubCredentialFetcherOptions extends CommonCredentialFetcherOptions {
   /**
    * Optional GitHub username to select appropriate account.
    */
@@ -271,8 +271,8 @@ export class Github {
    * });
    * ```
    */
-  createCredentialFetcher(options: GithubAccountInjectionOptions): CredentialFetcher<AccessTokenCredential> {
-    return registerAccountInjection<AccessTokenCredential>("github", {
+  createCredentialFetcher(options: GithubCredentialFetcherOptions): CredentialFetcher<AccessTokenCredential> {
+    return registerCredentialFetcher<AccessTokenCredential>("github", {
       description: options.description,
       selector: options.username,
       scopes: options.scopes,

--- a/integrations/google/runtime.ts
+++ b/integrations/google/runtime.ts
@@ -1,7 +1,7 @@
-import type { CommonAccountInjectionOptions } from "../../common.ts";
-import { type AccessTokenCredential, type CredentialFetcher, registerAccountInjection } from "../../runtimeSupport.ts";
+import type { CommonCredentialFetcherOptions } from "../../common.ts";
+import { type AccessTokenCredential, type CredentialFetcher, registerCredentialFetcher } from "../../runtimeSupport.ts";
 
-export interface GoogleAccountInjectionOptions extends CommonAccountInjectionOptions {
+export interface GoogleCredentialFetcherOptions extends CommonCredentialFetcherOptions {
   /**
    * Optional email address to select appropriate account.
    *
@@ -34,8 +34,8 @@ export class Google {
    * });
    * ```
    */
-  createCredentialFetcher(options: GoogleAccountInjectionOptions): CredentialFetcher<AccessTokenCredential> {
-    return registerAccountInjection<AccessTokenCredential>("google", {
+  createCredentialFetcher(options: GoogleCredentialFetcherOptions): CredentialFetcher<AccessTokenCredential> {
+    return registerCredentialFetcher<AccessTokenCredential>("google", {
       description: options.description,
       selector: options.accountEmailAddress,
       scopes: options.scopes,

--- a/integrations/resend/runtime.ts
+++ b/integrations/resend/runtime.ts
@@ -1,7 +1,7 @@
-import type { CommonAccountInjectionOptions } from "../../common.ts";
-import { type ApiKeyCredential, type CredentialFetcher, registerAccountInjection } from "../../runtimeSupport.ts";
+import type { CommonCredentialFetcherOptions } from "../../common.ts";
+import { type ApiKeyCredential, type CredentialFetcher, registerCredentialFetcher } from "../../runtimeSupport.ts";
 
-export interface ResendAccountInjectionOptions extends CommonAccountInjectionOptions {
+export interface ResendCredentialFetcherOptions extends CommonCredentialFetcherOptions {
   /** Optional API key name to select appropriate api key. */
   apiKeyName?: string;
 }
@@ -30,8 +30,8 @@ export interface ResendAccountInjectionOptions extends CommonAccountInjectionOpt
  * @see https://resend.com/docs/api-reference
  */
 export class Resend {
-  createCredentialFetcher(options?: ResendAccountInjectionOptions): CredentialFetcher<ApiKeyCredential> {
-    return registerAccountInjection<ApiKeyCredential>("resend", {
+  createCredentialFetcher(options?: ResendCredentialFetcherOptions): CredentialFetcher<ApiKeyCredential> {
+    return registerCredentialFetcher<ApiKeyCredential>("resend", {
       description: options?.description,
       selector: options?.apiKeyName,
     });

--- a/integrations/slack/runtime.ts
+++ b/integrations/slack/runtime.ts
@@ -1,6 +1,6 @@
 import z from "zod";
-import { type CommonAccountInjectionOptions, CommonTriggerBackendConfig, type CommonTriggerOptions } from "../../common.ts";
-import { type AccessTokenCredential, type CredentialFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
+import { type CommonCredentialFetcherOptions, CommonTriggerBackendConfig, type CommonTriggerOptions } from "../../common.ts";
+import { type AccessTokenCredential, type CredentialFetcher, registerCredentialFetcher, registerEventListener } from "../../runtimeSupport.ts";
 import type { AllMessageEvents, GenericMessageEvent, SlackEvent } from "@slack/types";
 import { type ChatPostMessageResponse, ErrorCode, type WebAPIPlatformError, WebClient } from "@slack/web-api";
 
@@ -59,7 +59,7 @@ export const SlackTriggerBackendConfig: z.ZodType<SlackTriggerBackendConfig> = C
   channels: z.array(z.string()).optional(),
 });
 
-export interface SlackCredentialFetcherOptions extends CommonAccountInjectionOptions {
+export interface SlackCredentialFetcherOptions extends CommonCredentialFetcherOptions {
   scopes: string[];
   teamId?: string;
 }
@@ -171,7 +171,7 @@ export class Slack {
    * ```
    */
   createUserCredentialFetcher(options: SlackCredentialFetcherOptions): CredentialFetcher<AccessTokenCredential> {
-    return registerAccountInjection<AccessTokenCredential>("slack", {
+    return registerCredentialFetcher<AccessTokenCredential>("slack", {
       description: options.description,
       selector: options.teamId,
       scopes: options.scopes,
@@ -200,7 +200,7 @@ export class Slack {
    * ```
    */
   createBotCredentialFetcher(options: SlackCredentialFetcherOptions): CredentialFetcher<AccessTokenCredential> {
-    return registerAccountInjection<AccessTokenCredential>("slackBot", {
+    return registerCredentialFetcher<AccessTokenCredential>("slackBot", {
       description: options.description,
       selector: options.teamId,
       scopes: options.scopes,

--- a/integrations/streak/runtime.ts
+++ b/integrations/streak/runtime.ts
@@ -1,6 +1,6 @@
 import z from "zod";
-import { type CommonAccountInjectionOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
-import { type ApiKeyCredential, type CredentialFetcher, registerAccountInjection, registerEventListener } from "../../runtimeSupport.ts";
+import { type CommonCredentialFetcherOptions, type CommonTriggerBackendConfig, CommonTriggerOptions } from "../../common.ts";
+import { type ApiKeyCredential, type CredentialFetcher, registerCredentialFetcher, registerEventListener } from "../../runtimeSupport.ts";
 
 /**
  * Options specific to Streak event triggers.
@@ -27,7 +27,7 @@ export const StreakTriggerBackendConfig = CommonTriggerOptions.extend({
   emailAddress: z.string().optional(),
 }) as z.ZodType<StreakTriggerBackendConfig>; // doing a cast only because we have a looser type for event
 
-export interface StreakAccountInjectionOptions extends CommonAccountInjectionOptions {
+export interface StreakCredentialFetcherOptions extends CommonCredentialFetcherOptions {
   /** Optional email address to select appropriate account. */
   emailAddress?: string;
 }
@@ -159,8 +159,8 @@ export class Streak {
     this.onBoxEvent("MEETING_CREATE", pipelineKey, fn, options);
   }
 
-  createCredentialFetcher(options?: StreakAccountInjectionOptions): CredentialFetcher<ApiKeyCredential> {
-    return registerAccountInjection<ApiKeyCredential>("streak", {
+  createCredentialFetcher(options?: StreakCredentialFetcherOptions): CredentialFetcher<ApiKeyCredential> {
+    return registerCredentialFetcher<ApiKeyCredential>("streak", {
       description: options?.description,
       selector: options?.emailAddress,
     });

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -20,7 +20,7 @@ Deno.test({
       callCount++;
       console.log("debug callback");
     }, { custom: 123 });
-    const _testCredentialFetcher = glue.debug.registerRawAccountInjection("testAccount", { scopes: ["foo"] });
+    const _testCredentialFetcher = glue.debug.registerRawCredentialFetcher("testAccount", { scopes: ["foo"] });
 
     await Promise.resolve();
 

--- a/mod.ts
+++ b/mod.ts
@@ -19,18 +19,18 @@ import { Resend } from "./integrations/resend/runtime.ts";
 export type { Resend };
 import { Debug } from "./integrations/debug/runtime.ts";
 export type { Debug };
-export type { GoogleAccountInjectionOptions } from "./integrations/google/runtime.ts";
+export type { GoogleCredentialFetcherOptions } from "./integrations/google/runtime.ts";
 export type { GmailMessageEvent, GmailTriggerOptions } from "./integrations/gmail/runtime.ts";
 export type { GithubEvent, GithubTriggerOptions } from "./integrations/github/runtime.ts";
 export type { WebhookEvent, WebhookTriggerOptions } from "./integrations/webhook/runtime.ts";
 export type { CronEvent } from "./integrations/cron/runtime.ts";
-export type { BoxEventType, StreakAccountInjectionOptions, StreakEvent, StreakTriggerOptions } from "./integrations/streak/runtime.ts";
+export type { BoxEventType, StreakCredentialFetcherOptions, StreakEvent, StreakTriggerOptions } from "./integrations/streak/runtime.ts";
 export type { StripeEvent, StripeTriggerOptions } from "./integrations/stripe/runtime.ts";
 export type { IntercomEvent, IntercomTriggerOptions } from "./integrations/intercom/runtime.ts";
 export type { SlackCredentialFetcherOptions, SlackEventWebhook, SlackTriggerOptions } from "./integrations/slack/runtime.ts";
-export type { ResendAccountInjectionOptions } from "./integrations/resend/runtime.ts";
+export type { ResendCredentialFetcherOptions } from "./integrations/resend/runtime.ts";
 export type { AccessTokenCredential, ApiKeyCredential, CredentialFetcher } from "./runtimeSupport.ts";
-export type { CommonAccountInjectionOptions, CommonTriggerOptions } from "./common.ts";
+export type { CommonCredentialFetcherOptions, CommonTriggerOptions } from "./common.ts";
 
 /**
  * The main Glue runtime class that provides access to all event sources.

--- a/runtimeSupport.ts
+++ b/runtimeSupport.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { retry } from "@std/async/retry";
-import { type AccessTokenCredential, type AccountInjectionBackendConfig, type ApiKeyCredential, type Registrations, TriggerEvent } from "./backendTypes.ts";
+import { type AccessTokenCredential, type ApiKeyCredential, type CredentialFetcherBackendConfig, type Registrations, TriggerEvent } from "./backendTypes.ts";
 export type { AccessTokenCredential, ApiKeyCredential };
 import { type Log, patchConsoleGlobal, runInLoggingContext } from "./logging.ts";
 import type { CommonTriggerOptions } from "./common.ts";
@@ -17,14 +17,14 @@ interface RegisteredEvent {
   config: unknown;
 }
 
-interface RegisteredAccountInjection {
-  config: AccountInjectionBackendConfig;
+interface RegisteredCredentialFetcher {
+  config: CredentialFetcherBackendConfig;
 }
 
 const eventListenersByType = new Map<string, Map<string, RegisteredEvent>>();
-const accountInjectionsByType = new Map<
+const credentialFetchersByType = new Map<
   string,
-  Map<string, RegisteredAccountInjection>
+  Map<string, RegisteredCredentialFetcher>
 >();
 
 let nextAutomaticLabel = 0;
@@ -78,19 +78,19 @@ export interface CredentialFetcher<T> {
  * Registers a credential fetcher for a specific service type. This function is
  * used internally by event source implementations.
  */
-export function registerAccountInjection<T extends AccessTokenCredential | ApiKeyCredential>(
+export function registerCredentialFetcher<T extends AccessTokenCredential | ApiKeyCredential>(
   type: string,
-  config: AccountInjectionBackendConfig,
+  config: CredentialFetcherBackendConfig,
 ): CredentialFetcher<T> {
   scheduleInit();
-  let typeAccountInjections = accountInjectionsByType.get(type);
-  if (!typeAccountInjections) {
-    typeAccountInjections = new Map();
-    accountInjectionsByType.set(type, typeAccountInjections);
+  let credentialFetchersOfType = credentialFetchersByType.get(type);
+  if (!credentialFetchersOfType) {
+    credentialFetchersOfType = new Map();
+    credentialFetchersByType.set(type, credentialFetchersOfType);
   }
 
   const resolvedLabel = String(nextAutomaticLabel++);
-  if (typeAccountInjections.has(resolvedLabel)) {
+  if (credentialFetchersOfType.has(resolvedLabel)) {
     throw new Error(
       `Credential fetcher with label ${
         JSON.stringify(
@@ -99,7 +99,7 @@ export function registerAccountInjection<T extends AccessTokenCredential | ApiKe
       } already registered`,
     );
   }
-  typeAccountInjections.set(resolvedLabel, {
+  credentialFetchersOfType.set(resolvedLabel, {
     config,
   });
 
@@ -149,7 +149,7 @@ function getRegistrations(): Registrations {
         ),
     ),
     accountInjections: Array.from(
-      accountInjectionsByType.entries()
+      credentialFetchersByType.entries()
         .flatMap(([type, requests]) =>
           requests.entries().map(([label, { config }]) => ({
             type,


### PR DESCRIPTION
Follow-up to https://github.com/StreakYC/glue-runtime/pull/13. Removes all mentions of "account injections" from type names. Now the only the mentions of "account injections" are internal, in URLs and property names shared with the backend.

This change may be a breaking change for type-checking of existing glues. This change does not affect runtime behavior and won't break any already-deployed glues.