### PR TITLE
Log error cause property

### DIFF
--- a/logging/indentLines.test.ts
+++ b/logging/indentLines.test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from "@std/assert";
+import { indentLines } from "./indentLines.ts";
+
+Deno.test("indentLines", () => {
+  const text = "line1\nline2\nline3";
+  const indented = indentLines(text, ">>");
+  assertEquals(indented, ">>line1\n>>line2\n>>line3");
+});
+
+Deno.test("indentLines ignores empty lines", () => {
+  const text = "line1\n\nline3\n";
+  const indented = indentLines(text, ">>");
+  assertEquals(indented, ">>line1\n\n>>line3\n");
+});

--- a/logging/indentLines.ts
+++ b/logging/indentLines.ts
@@ -1,0 +1,3 @@
+export function indentLines(text: string, indent: string = "  "): string {
+  return text.split("\n").map((line) => (line ? indent + line : line)).join("\n");
+}

--- a/logging/serialization.test.ts
+++ b/logging/serialization.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { serializeConsoleArgumentsToString } from "./serialization.ts";
+import { indentLines } from "./indentLines.ts";
 
 Deno.test("serializeConsoleArgumentsToString", () => {
   const text = serializeConsoleArgumentsToString([
@@ -31,6 +32,20 @@ Deno.test("serializeConsoleArgumentsToString handles errors", () => {
   const err = new Error("Test");
   const text = serializeConsoleArgumentsToString([err]);
   assertEquals(text, `${err.stack}`);
+});
+
+Deno.test("serializeConsoleArgumentsToString handles errors with cause property", () => {
+  const cause = new Error("Cause");
+  const err = new Error("Test", { cause });
+  const text = serializeConsoleArgumentsToString([err]);
+  assertEquals(text, `${err.stack} {\n${indentLines(`cause: ${cause.stack}`)}\n}`);
+});
+
+Deno.test("serializeConsoleArgumentsToString handles errors with self-referential cause property", () => {
+  const err = new Error("Test");
+  err.cause = err;
+  const text = serializeConsoleArgumentsToString([err]);
+  assertEquals(text, `${err.stack} {\n${indentLines(`cause: [Circular reference]`)}\n}`);
 });
 
 Deno.test("serializeConsoleArgumentsToString handles Sets", () => {

--- a/logging/serialization.ts
+++ b/logging/serialization.ts
@@ -1,3 +1,5 @@
+import { indentLines } from "./indentLines.ts";
+
 function serializeValue(value: unknown, stack?: unknown[]): string {
   if (
     value == null ||
@@ -12,9 +14,6 @@ function serializeValue(value: unknown, stack?: unknown[]): string {
   if (typeof value === "function") {
     return value.name ? `[Function: ${value.name}]` : "[Function (anonymous)]";
   }
-  if (value instanceof Error) {
-    return value.stack ?? String(value);
-  }
 
   // potentially recursive and fallible cases below
 
@@ -28,6 +27,14 @@ function serializeValue(value: unknown, stack?: unknown[]): string {
     stack.push(value);
   }
   try {
+    if (value instanceof Error) {
+      let errString = value.stack ?? String(value);
+      const { cause } = value;
+      if (cause) {
+        errString += ` {\n${indentLines(`cause: ${serializeValue(cause, stack)}`)}\n}`;
+      }
+      return errString;
+    }
     if (value instanceof Set) {
       return `Set(${value.size}) { ${
         Array.from(value).map((x) => serializeValue(x, stack)).join(", ")

--- a/logging/serialization.ts
+++ b/logging/serialization.ts
@@ -30,7 +30,7 @@ function serializeValue(value: unknown, stack?: unknown[]): string {
     if (value instanceof Error) {
       let errString = value.stack ?? String(value);
       const { cause } = value;
-      if (cause) {
+      if (cause !== undefined) {
         errString += ` {\n${indentLines(`cause: ${serializeValue(cause, stack)}`)}\n}`;
       }
       return errString;


### PR DESCRIPTION
The `cause` property of Errors was not logged. This property is used by the retry function from `@std/async` to report the original error when a retry limit is hit.